### PR TITLE
Fix the authentication guard loading state; otherwise working fine

### DIFF
--- a/bi-frontend/src/components/authentication-guard.tsx
+++ b/bi-frontend/src/components/authentication-guard.tsx
@@ -1,6 +1,6 @@
 import { withAuthenticationRequired } from "@auth0/auth0-react";
 import React, { type ComponentType } from "react";
-// import { PageLoader } from "./page-loader";
+import { Spinner } from "@/components/ui/spinner";
 
 interface AuthenticationGuardProps {
   component: ComponentType;
@@ -10,11 +10,12 @@ export const AuthenticationGuard: React.FC<AuthenticationGuardProps> = ({
   component,
 }) => {
   const Component = withAuthenticationRequired(component, {
-    // onRedirecting: () => (
-    //   <div className="page-layout">
-    //     <PageLoader />
-    //   </div>
-    // ),
+    onRedirecting: () => (
+      <div className="flex flex-col items-center justify-center h-screen">
+        <Spinner className="size-24" />
+        <p className="font-bold">Loading..</p>
+      </div>
+    ),
   });
 
   return <Component />;


### PR DESCRIPTION
Fixes #46 

The client loaders fire before the authentication guard, so those handle the redirect in many cases. But for pages that don't use a client loader that authenticates, such as `/formula/new`, the authentication guard kicks in just fine, and does the redirect.

This just adds a better redirecting state.