### PR TITLE
Persist quantity/weight per formula using metas

### DIFF
--- a/bi-backend/Makefile
+++ b/bi-backend/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build migrate-staging migrate-local
-build: lambda-handlers/formulas-get/bootstrap.zip lambda-handlers/formula-get/bootstrap.zip lambda-handlers/formula-delete/bootstrap.zip lambda-handlers/formula-put/bootstrap.zip lambda-handlers/formula-post/bootstrap.zip
+build: lambda-handlers/formulas-get/bootstrap.zip lambda-handlers/formula-get/bootstrap.zip lambda-handlers/formula-delete/bootstrap.zip lambda-handlers/formula-put/bootstrap.zip lambda-handlers/formula-post/bootstrap.zip lambda-handlers/formula-meta-patch/bootstrap.zip
 
 lambda-handlers/%/bootstrap.zip: lambda-handlers/%/bootstrap
 	zip -j $@ $<

--- a/bi-backend/lambda-handlers/formula-meta-patch/handler.go
+++ b/bi-backend/lambda-handlers/formula-meta-patch/handler.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"strconv"
+
+	lambdahandlers "bi-backend/lambda-handlers"
+	"bi-backend/lib"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"gorm.io/gorm"
+)
+
+var db *gorm.DB
+
+func init() {
+	maybeDb, err := lib.Connect()
+	if err != nil {
+		log.Fatalf("failed to connect database, %v", err)
+	}
+	db = maybeDb
+}
+
+func handleRequest(userId string, pathParameters map[string]string, body string) (any, error) {
+	formulaId, err := strconv.ParseUint(pathParameters["formulaId"], 10, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var metas []lib.FormulaMeta
+	if err := json.Unmarshal([]byte(body), &metas); err != nil {
+		return nil, err
+	}
+
+	return lib.UpsertFormulaMetas(db, userId, uint(formulaId), metas)
+}
+
+func main() {
+	lambda.Start(lambdahandlers.WrapHandler(handleRequest))
+}

--- a/bi-backend/lib/db.go
+++ b/bi-backend/lib/db.go
@@ -132,6 +132,26 @@ func EditFormula(db *gorm.DB, userId string, formulaId uint, formulaInput *Formu
 	return *formulaInput, err
 }
 
+func UpsertFormulaMetas(db *gorm.DB, userId string, formulaId uint, metas []FormulaMeta) ([]FormulaMeta, error) {
+	ctx := context.Background()
+	// Verify formula belongs to user
+	_, err := gorm.G[Formula](db).Where(&Formula{Model: Model{ID: formulaId}, User: userId}).First(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Upsert each meta by type (insert if not exists, update value if exists)
+	for i, meta := range metas {
+		metas[i].FormulaID = formulaId
+		err = db.Where(FormulaMeta{FormulaID: formulaId, Type: meta.Type}).
+			Assign(FormulaMeta{Value: meta.Value}).
+			FirstOrCreate(&metas[i]).Error
+		if err != nil {
+			return nil, err
+		}
+	}
+	return metas, nil
+}
+
 func DeleteFormula(db *gorm.DB, userId string, formulaId uint) error {
 	// do this delete with the traditional API to handle cleaning up the relations along with the formula
 	err := db.Select(clause.Associations).Where(&Formula{User: userId}).Delete(&Formula{Model: Model{ID: formulaId}}).Error

--- a/bi-backend/main.go
+++ b/bi-backend/main.go
@@ -125,6 +125,30 @@ func main() {
 		json.NewEncoder(w).Encode(fullFormula)
 	})).Methods("PUT")
 
+	r.HandleFunc("/formula/{formulaId}/meta", middleware.ValidateJWT(audience, domain, func(w http.ResponseWriter, r *http.Request) {
+		userId, err := checkUser(w, r)
+		if err != nil {
+			return
+		}
+
+		vars := mux.Vars(r)
+		formulaId, err := strconv.ParseUint(vars["formulaId"], 10, 0)
+		if err != nil {
+			http.Error(w, "failed to parse formula id", http.StatusInternalServerError)
+			return
+		}
+
+		var metas []lib.FormulaMeta
+		json.NewDecoder(r.Body).Decode(&metas)
+
+		result, err := lib.UpsertFormulaMetas(db, userId, uint(formulaId), metas)
+		if err != nil {
+			http.Error(w, "failed to patch metas", http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(result)
+	})).Methods("PATCH")
+
 	r.HandleFunc("/formula", middleware.ValidateJWT(audience, domain, func(w http.ResponseWriter, r *http.Request) {
 		userId, err := checkUser(w, r)
 		if err != nil {
@@ -146,7 +170,7 @@ func main() {
 	r.HandleFunc("/", middleware.NotFoundHandler)
 
 	// TODO: better CORS headers
-	corsWrap := handlers.CORS(handlers.AllowedOrigins([]string{"*"}), handlers.AllowedHeaders([]string{"Authorization", "Content-Type"}), handlers.AllowedMethods([]string{"GET", "POST", "DELETE", "PUT"}))(r)
+	corsWrap := handlers.CORS(handlers.AllowedOrigins([]string{"*"}), handlers.AllowedHeaders([]string{"Authorization", "Content-Type"}), handlers.AllowedMethods([]string{"GET", "POST", "DELETE", "PUT", "PATCH"}))(r)
 
 	// log our requests
 	logWrap := handlers.LoggingHandler(os.Stdout, corsWrap)

--- a/bi-frontend/src/Formula.tsx
+++ b/bi-frontend/src/Formula.tsx
@@ -1,4 +1,4 @@
-import { deleteFormula, editFormula, type Formula, loadFormula, upsertMeta } from "@/api";
+import { deleteFormula, editFormula, type Formula, loadFormula, patchFormulaMetas, upsertMeta } from "@/api";
 import queryClient from "@/query-client";
 import client from "@/auth0-client";
 import { useNavigate, useRevalidator } from "react-router";
@@ -6,7 +6,7 @@ import { Field, FieldGroup, FieldLabel, FieldLegend, FieldSet } from "@/componen
 import { Button } from "@/components/ui/button";
 import { Pencil, Trash } from "lucide-react";
 import { Table, TableCaption, TableHeader, TableHead, TableRow, TableBody, TableCell, TableFooter } from "@/components/ui/table";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import FormulaForm, { type FormSchema } from "@/components/formula-form";
@@ -40,9 +40,31 @@ function Formula({ loaderData: formula }: { loaderData: Formula | undefined }) {
   const { revalidate } = useRevalidator();
   const [state, setState] = useState<State>("normal");
 
-  // TODO: eventually these need to be persisted per-formula in meta
-  const [quantity, setQuantity] = useState(1);
-  const [weightPer, setWeightPer] = useState(875);
+  const [quantity, setQuantity] = useState(() => {
+    const v = formula.metas.find((m) => m.type === "quantity")?.value;
+    return v ? parseInt(v) : 1;
+  });
+  const [weightPer, setWeightPer] = useState(() => {
+    const v = formula.metas.find((m) => m.type === "weightPer")?.value;
+    return v ? parseFloat(v) : 875;
+  });
+
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const saveMetas = async (q: number, w: number) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = null;
+    const token = await client.getTokenSilently();
+    await patchFormulaMetas(token, formula.id, [
+      { type: "quantity", value: String(q) },
+      { type: "weightPer", value: String(w) },
+    ]);
+  };
+
+  const scheduleSave = (q: number, w: number) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => saveMetas(q, w), 800);
+  };
 
   if (!formula) {
     return;
@@ -133,11 +155,11 @@ function Formula({ loaderData: formula }: { loaderData: Formula | undefined }) {
               <FieldGroup>
                 <Field orientation="horizontal">
                   <FieldLabel>Quantity</FieldLabel>
-                  <Input type="number" value={quantity} onChange={(e) => setQuantity(parseInt(e.target.value))} />
+                  <Input type="number" value={quantity} onChange={(e) => { const v = parseInt(e.target.value); setQuantity(v); scheduleSave(v, weightPer); }} onBlur={() => saveMetas(quantity, weightPer)} />
                 </Field>
                 <Field orientation="horizontal">
                   <FieldLabel>Weight Per</FieldLabel>
-                  <Input type="number" value={weightPer} onChange={(e) => setWeightPer(parseFloat(e.target.value))} />
+                  <Input type="number" value={weightPer} onChange={(e) => { const v = parseFloat(e.target.value); setWeightPer(v); scheduleSave(quantity, v); }} onBlur={() => saveMetas(quantity, weightPer)} />
                 </Field>
               </FieldGroup>
             </FieldSet>

--- a/bi-frontend/src/api.ts
+++ b/bi-frontend/src/api.ts
@@ -123,6 +123,22 @@ export async function editFormula(
   return fullFormula;
 }
 
+export async function patchFormulaMetas(
+  accessToken: string,
+  formulaId: number,
+  metas: MetaInput[],
+) {
+  return await upfetch(
+    import.meta.env.VITE_API_BASE + "/formula/" + formulaId + "/meta",
+    {
+      method: "PATCH",
+      body: metas,
+      schema: z.array(Meta),
+      headers: { Authorization: "Bearer " + accessToken },
+    },
+  );
+}
+
 export async function deleteFormula(accessToken: string, formulaId: number) {
   const status = await upfetch(
     import.meta.env.VITE_API_BASE + "/formula/" + formulaId,

--- a/bi-infrastructure/index.ts
+++ b/bi-infrastructure/index.ts
@@ -121,6 +121,10 @@ const apiRoutes = [
         pathKey: "formula-post",
         routeKey: "POST /api/formula",
     },
+    {
+        pathKey: "formula-meta-patch",
+        routeKey: "PATCH /api/formula/{formulaId}/meta",
+    },
 ];
 
 const routeObjects = apiRoutes.map(({ pathKey, routeKey }) => {


### PR DESCRIPTION
Fixes #57

## Summary

- Adds `PATCH /formula/{formulaId}/meta` endpoint that upserts metas by type (no deletion, lighter than PUT which replaces the full formula)
- Backend: `UpsertFormulaMetas` in `lib/db.go`, new Lambda handler in `lambda-handlers/formula-meta-patch/`, new route in `main.go`, Makefile and Pulumi infra updated
- Frontend: `quantity` and `weightPer` now initialize from stored metas (with fallback defaults 1 and 875); saves debounce 800ms on change and flush immediately on blur

## Test plan

- [x] Open a formula, change Quantity and Weight Per, wait 800ms, reload — values persist
- [x] Change a value and immediately tab/click away (blur) — saves instantly, persists on reload
- [x] Two different formulas have independent quantity/weightPer values
- [x] Description meta is unaffected by PATCH calls (only upserts types sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)