### PR TITLE
Show description preview in formula cards on list page

### DIFF
--- a/bi-backend/lib/db.go
+++ b/bi-backend/lib/db.go
@@ -72,10 +72,10 @@ func SetupDB(db *gorm.DB) error {
 }
 
 func GetFormulas(db *gorm.DB, userId string) ([]Formula, error) {
-	ctx := context.Background()
-	// TOOD: would love to get description in here
-	formulas, err := gorm.G[Formula](db).Where(&Formula{User: userId}).Find(ctx)
-
+	var formulas []Formula
+	err := db.Where(&Formula{User: userId}).
+		Preload("Metas", "type = ?", "description").
+		Find(&formulas).Error
 	return formulas, err
 }
 

--- a/bi-frontend/src/Formulas.tsx
+++ b/bi-frontend/src/Formulas.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router";
 import { loadFormulas, type Formulas } from "./api"
 import queryClient from "@/query-client";
 import client from "@/auth0-client";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/empty-state";
 
 export const handle = {
@@ -35,6 +35,13 @@ function Formulas({ loaderData: formulas }: { loaderData: Formulas | undefined }
                 <Link to={"/formula/" + item.id}>{item.name}</Link>
               </CardTitle>
             </CardHeader>
+            {item.metas.find((m) => m.type === "description")?.value && (
+              <CardContent>
+                <p className="text-sm text-muted-foreground line-clamp-2">
+                  {item.metas.find((m) => m.type === "description")?.value}
+                </p>
+              </CardContent>
+            )}
           </Card>
         ))}
       </div>}

--- a/bi-frontend/src/api.ts
+++ b/bi-frontend/src/api.ts
@@ -23,7 +23,7 @@ const Formula = z.object({
   metas: z.array(Meta),
 });
 
-const Formulas = z.array(z.object({id: z.number(), name: z.string()}));
+const Formulas = z.array(z.object({id: z.number(), name: z.string(), metas: z.array(Meta)}));
 
 const MetaInput = z.object({
   id: z.number().optional(),


### PR DESCRIPTION
## Summary

- `GetFormulas` now preloads only description metas via a conditional `Preload("Metas", "type = ?", "description")`, issuing two queries total (no N+1)
- Frontend `Formulas` API schema updated to include `metas` array
- Formula cards on the list page show a 2-line clamped description preview when one exists; cards without a description are unchanged

## Test plan

- [x] Open the formulas list — cards with a description show truncated text below the name
- [x] Cards without a description show no extra content
- [x] Long descriptions are visually clamped to 2 lines
- [x] Verify no regression on the individual formula page

🤖 Generated with [Claude Code](https://claude.com/claude-code)